### PR TITLE
Milvus增加用户名、密码、数据库名支持

### DIFF
--- a/qanything_kernel/configs/model_config.py
+++ b/qanything_kernel/configs/model_config.py
@@ -62,6 +62,9 @@ ZH_TITLE_ENHANCE = False
 MILVUS_HOST_LOCAL = 'milvus-standalone-local'
 MILVUS_HOST_ONLINE = 'milvus-standalone-local'
 MILVUS_PORT = 19530
+MILVUS_USER = ''
+MILVUS_PASSWORD = ''
+MILVUS_DB_NAME = ''
 
 MYSQL_HOST_LOCAL = 'mysql-container-local'
 MYSQL_HOST_ONLINE = 'mysql-container-local'

--- a/qanything_kernel/connector/database/milvus/milvus_client.py
+++ b/qanything_kernel/connector/database/milvus/milvus_client.py
@@ -6,7 +6,7 @@ from functools import partial
 import time
 import copy
 from datetime import datetime
-from qanything_kernel.configs.model_config import MILVUS_HOST_LOCAL, MILVUS_HOST_ONLINE, MILVUS_PORT, CHUNK_SIZE, VECTOR_SEARCH_TOP_K
+from qanything_kernel.configs.model_config import MILVUS_HOST_LOCAL, MILVUS_HOST_ONLINE, MILVUS_PORT, MILVUS_USER, MILVUS_PASSWORD, MILVUS_DB_NAME, CHUNK_SIZE, VECTOR_SEARCH_TOP_K
 from qanything_kernel.utils.custom_log import debug_logger
 from langchain.docstore.document import Document
 import math
@@ -28,6 +28,9 @@ class MilvusClient:
         else:
             self.host = MILVUS_HOST_ONLINE
         self.port = MILVUS_PORT
+        self.user = MILVUS_USER
+        self.password = MILVUS_PASSWORD
+        self.db_name = MILVUS_DB_NAME
         self.client_timeout = client_timeout
         self.threshold = threshold
         self.sess: Collection = None
@@ -79,7 +82,8 @@ class MilvusClient:
 
     def init(self):
         try:
-            connections.connect(host=self.host, port=self.port)  # timeout=3 [cannot set]
+            connections.connect(host=self.host, port=self.port, user=self.user,
+                                password=self.password, db_name=self.db_name)  # timeout=3 [cannot set]
             if utility.has_collection(self.user_id):
                 self.sess = Collection(self.user_id)
                 debug_logger.info(f'collection {self.user_id} exists')


### PR DESCRIPTION
在生产环境中，Milvus通常会开启鉴权和多数据库

本次提交主要解决2个问题：
1、当Milvus开启鉴权之后，需要使用用户名、密码才能连接
[Milvus官方文档Enable user authentication](https://milvus.io/docs/authenticate.md)
2、当Milvus存在多个database时，需要指定数据库名

本次提交的代码将不影响默认无用户名、密码、数据库名启动，如果填写了MILVUS_USER、MILVUS_PASSWORD、MILVUS_DB_NAME则会在创建客户端的时候传入用户名、密码、数据库名。
