### PR TITLE
fix: Privileged mode is incompatible with user namespaces

### DIFF
--- a/docker-compose-linux.yaml
+++ b/docker-compose-linux.yaml
@@ -67,6 +67,7 @@ services:
 
   mysql:
     container_name: mysql-container-local
+    userns_mode: host
     privileged: true
     image: mysql
     #     ports:
@@ -90,6 +91,7 @@ services:
 
     command: /bin/bash -c 'if [ "${LLM_API}" = "local" ]; then /workspace/qanything_local/scripts/run_for_local_option.sh -c $LLM_API -i $DEVICE_ID -b $RUNTIME_BACKEND -m $MODEL_NAME -t $CONV_TEMPLATE -p $TP -r $GPU_MEM_UTILI; else /workspace/qanything_local/scripts/run_for_cloud_option.sh -c $LLM_API -i $DEVICE_ID -b $RUNTIME_BACKEND; fi; while true; do sleep 5; done'
 
+    userns_mode: host
     privileged: true
     shm_size: '8gb'
     volumes:

--- a/docker-compose-windows.yaml
+++ b/docker-compose-windows.yaml
@@ -67,6 +67,7 @@ services:
 
   mysql:
     container_name: mysql-container-local
+    userns_mode: host
     privileged: true
     image: mysql
     #     ports:
@@ -88,6 +89,7 @@ services:
               count: "all"
               capabilities: ["gpu"]
     command: sh -c 'if [ "${LLM_API}" = "local" ]; then /workspace/qanything_local/scripts/run_for_local_option.sh -c $LLM_API -i $DEVICE_ID -b $RUNTIME_BACKEND -m $MODEL_NAME -t $CONV_TEMPLATE -p $TP -r $GPU_MEM_UTILI; else /workspace/qanything_local/scripts/run_for_cloud_option.sh -c $LLM_API -i $DEVICE_ID -b $RUNTIME_BACKEND; fi; while true; do sleep 5; done'
+    userns_mode: host
     privileged: true
     shm_size: '8gb'
     volumes:


### PR DESCRIPTION
fix the #190 Issue

The mysql and qanything_local containers use an option `privileged: true` in both `docker-compose-linux.yaml` and `docker-compose-windows.yaml`. However, the default namespace of docker container is user, which is not compatible for the `privileged: true` option. 

I fix this problem according to https://stackoverflow.com/questions/46975949/docker-compose-and-user-namespaces

And it works for me.

my environment:
- OS:Ubuntu 20.04.6 LTS
- NVIDIA Driver:530.41.03
- CUDA: V12.1.66
- docker: 24.0.6
- docker-compose:1.25.0
- NVIDIA GPU:RTX 4090
- NVIDIA GPU Memory: 24GB
