### PR TITLE
Read all sheets from excel file

### DIFF
--- a/qanything_kernel/core/local_file.py
+++ b/qanything_kernel/core/local_file.py
@@ -84,11 +84,14 @@ class LocalFile:
             docs = loader.load_and_split(texts_splitter)
         elif self.file_path.lower().endswith(".xlsx"):
             # loader = UnstructuredExcelLoader(self.file_path, mode="elements")
+            docs = []
             csv_file_path = self.file_path[:-5] + '.csv'
-            xlsx = pd.read_excel(self.file_path, engine='openpyxl')
-            xlsx.to_csv(csv_file_path, index=False)
-            loader = CSVLoader(csv_file_path, csv_args={"delimiter": ",", "quotechar": '"'})
-            docs = loader.load()
+            xlsx = pd.read_excel(self.file_path, engine='openpyxl', sheet_name=None)
+            for sheet in xlsx.keys():
+                csv_file_path = self.file_path[:-5] + '_' + sheet + '.csv'
+                xlsx[sheet].to_csv(csv_file_path, index=False)
+                loader = CSVLoader(csv_file_path, csv_args={"delimiter": ",", "quotechar": '"'})
+                docs += loader.load()
         elif self.file_path.lower().endswith(".pptx"):
             loader = UnstructuredPowerPointLoader(self.file_path, mode="elements")
             docs = loader.load()


### PR DESCRIPTION
pandas read_excel function reads first sheet of excel by default, data in rest sheets will lose, this PR read all sheets from excel file.