### PR TITLE
Ensure bare exception statements are raised

### DIFF
--- a/qanything_kernel/connector/llm/llm_for_openai_api.py
+++ b/qanything_kernel/connector/llm/llm_for_openai_api.py
@@ -108,7 +108,7 @@ class OpenAILLM(BaseAnswer, ABC):
             elif isinstance(message, str):
                 num_tokens += len(encoding.encode(message))
             else:
-                NotImplementedError(
+                raise NotImplementedError(
                 f"""num_tokens_from_messages() is not implemented message type {type(message)}. """
             )
 


### PR DESCRIPTION
This codemod fixes cases where an exception is referenced by itself in a statement without being raised. This most likely indicates a bug: you probably meant to actually raise the exception. 

Our changes look something like this:
```diff
try:
-   ValueError
+   raise ValueError
except:
    pass
```

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/tutorial/errors.html#raising-exceptions](https://docs.python.org/3/tutorial/errors.html#raising-exceptions)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/exception-without-raise](https://docs.pixee.ai/codemods/python/pixee_python_exception-without-raise)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Cpixeeai%2FQAnything%7C3b525e302fcccf1acaf367538b1710587af1a771)

<!--{"type":"DRIP","codemod":"pixee:python/exception-without-raise"}-->