### PR TITLE
Enhanced Script Compatibility, Unified Support for Docker Compose Commands

### DIFF
--- a/close.sh
+++ b/close.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# 检测支持的 Docker Compose 命令
+if docker compose version &>/dev/null; then
+  DOCKER_COMPOSE_CMD="docker compose"
+elif $DOCKER_COMPOSE_CMD version &>/dev/null; then
+  DOCKER_COMPOSE_CMD="docker-compose"
+else
+  echo "无法找到 'docker compose' 或 'docker-compose' 命令。"
+  exit 1
+fi
+
 if [ -e /proc/version ]; then
   if grep -qi microsoft /proc/version || grep -qi MINGW /proc/version; then
     if grep -qi microsoft /proc/version; then
@@ -7,10 +17,10 @@ if [ -e /proc/version ]; then
     else
         echo "Running under git bash"
     fi
-    docker-compose -p user -f docker-compose-windows.yaml down
+    $DOCKER_COMPOSE_CMD -p user -f docker-compose-windows.yaml down
   else
     echo "Running under native Linux"
-    docker-compose -p user -f docker-compose-linux.yaml down
+    $DOCKER_COMPOSE_CMD -p user -f docker-compose-linux.yaml down
   fi
 else
   echo "/proc/version 文件不存在。请确认自己位于Linux或Windows的WSL环境下"

--- a/close.sh
+++ b/close.sh
@@ -3,7 +3,7 @@
 # 检测支持的 Docker Compose 命令
 if docker compose version &>/dev/null; then
   DOCKER_COMPOSE_CMD="docker compose"
-elif $DOCKER_COMPOSE_CMD version &>/dev/null; then
+elif docker-compose version &>/dev/null; then
   DOCKER_COMPOSE_CMD="docker-compose"
 else
   echo "无法找到 'docker compose' 或 'docker-compose' 命令。"

--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,16 @@ update_or_append_to_env() {
   fi
 }
 
+# 检测支持的 Docker Compose 命令
+if docker compose version &>/dev/null; then
+  DOCKER_COMPOSE_CMD="docker compose"
+elif docker-compose version &>/dev/null; then
+  DOCKER_COMPOSE_CMD="docker-compose"
+else
+  echo "无法找到 'docker compose' 或 'docker-compose' 命令。"
+  exit 1
+fi
+
 script_name=$(basename "$0")
 
 usage() {
@@ -279,22 +289,22 @@ if [ -e /proc/version ]; then
         echo "Running under git bash"
     fi
     
-    if docker-compose -p user -f docker-compose-windows.yaml down |& tee /dev/tty | grep -q "services.qanything_local.deploy.resources.reservations value 'devices' does not match any of the regexes"; then
+    if $DOCKER_COMPOSE_CMD -p user -f docker-compose-windows.yaml down |& tee /dev/tty | grep -q "services.qanything_local.deploy.resources.reservations value 'devices' does not match any of the regexes"; then
         echo "检测到 Docker Compose 版本过低，请升级到v2.23.3或更高版本。执行docker-compose -v查看版本。"
     fi
     mkdir -p volumes/es/data
     chmod 777 -R volumes/es/data
-    docker-compose -p user -f docker-compose-windows.yaml up -d
-    docker-compose -p user -f docker-compose-windows.yaml logs -f qanything_local
+    $DOCKER_COMPOSE_CMD -p user -f docker-compose-windows.yaml up -d
+    $DOCKER_COMPOSE_CMD -p user -f docker-compose-windows.yaml logs -f qanything_local
   else
     echo "Running under native Linux"
-    if docker-compose -p user -f docker-compose-linux.yaml down |& tee /dev/tty | grep -q "services.qanything_local.deploy.resources.reservations value 'devices' does not match any of the regexes"; then
+    if $DOCKER_COMPOSE_CMD -p user -f docker-compose-linux.yaml down |& tee /dev/tty | grep -q "services.qanything_local.deploy.resources.reservations value 'devices' does not match any of the regexes"; then
         echo "检测到 Docker Compose 版本过低，请升级到v2.23.3或更高版本。执行docker-compose -v查看版本。"
     fi
     mkdir -p volumes/es/data
     chmod 777 -R volumes/es/data
-    docker-compose -p user -f docker-compose-linux.yaml up -d
-    docker-compose -p user -f docker-compose-linux.yaml logs -f qanything_local
+    $DOCKER_COMPOSE_CMD -p user -f docker-compose-linux.yaml up -d
+    $DOCKER_COMPOSE_CMD -p user -f docker-compose-linux.yaml logs -f qanything_local
     # 检查日志输出
   fi
 else


### PR DESCRIPTION
# Eng Ver.

Dear Project Maintainers,

First and foremost, I would like to express my profound gratitude to you and the entire project team for the significant assistance and inspiration this project has provided in my career. I noticed that with the integration of Docker Compose V2 into Docker Desktop, the traditional `docker-compose` command has gradually been replaced by the new `docker compose` command. To enhance the script's compatibility and future maintainability, I have proposed several improvements.

I have added detection for both `docker compose` and `docker-compose` commands in the `run.sh` script, allowing it to automatically select the available command based on the current system environment. This change ensures that the script can run smoothly in different settings, whether the system has been updated to the latest version of Docker Desktop or is still using an older version.

Here are the specific changes I made:
1. Added detection for both `docker compose` and `docker-compose` commands.
2. Replaced all direct calls to `docker-compose` with a variable `$DOCKER_COMPOSE_CMD`, which decides the specific command to use based on the detection result.
3. Added error handling; if neither command is detected, the script will output an error message and exit.

According to the official [documentation](https://docs.docker.com/compose/migrate/) , since July 2023, Docker has integrated Compose V2 into all current versions of Docker Desktop, replacing `docker-compose`. This integration means that for all users who have installed a Docker version supporting the `docker compose` command, only Docker CLI needs to be maintained, further simplifying deployment and maintenance processes. This unification helps reduce dependency on outdated tools, ensuring a smoother transition to the latest Docker environment and reducing potential technical debt.

This approach ensures that the deployment process for the QAnything project is more direct and efficient, reducing dependency on outdated tools and aligning the project with the latest technical standards. This has long-term positive implications for enhancing user experience and development efficiency.

I hope these changes will add value to the project and look forward to continuing to gain valuable experience from it. I eagerly await your feedback, and once again, thank you and the team for your hard work.

Yours sincerely,

---

# 中文版

尊敬的项目管理者，

首先，我想对您以及整个项目团队表达我的深深感谢，此项目在我职业生涯中提供了极大的帮助和启发。在使用过程中，我注意到随着Docker Compose V2的整合进Docker Desktop，原有的`docker-compose`命令逐渐被新的`docker compose`命令替代。为了提升脚本的兼容性和未来的可维护性，我提出了一些改进。

我在`run.sh`脚本中增加了对`docker compose`和`docker-compose`命令的检测，使其能根据当前系统中可用的命令自动选择使用。此改动旨在确保脚本在不同环境下都能顺利运行，无论是已经更新至最新版Docker Desktop的系统，还是仍然使用旧版的系统。

以下是我所作的具体改动：
1. 增加了对`docker compose`和`docker-compose`命令的检测。
2. 将所有原先直接调用`docker-compose`的地方改为通过一个变量`$DOCKER_COMPOSE_CMD`来调用，该变量根据命令检测结果决定具体使用哪个命令。
3. 增加了错误处理，如果两个命令都检测不到，脚本将输出错误信息并退出。

根据[官方文档](https://docs.docker.com/compose/migrate/)，自从2023年7月，Docker将Compose V2整合到了所有当前的Docker Desktop版本中，取代了`docker-compose`。这一改变意味着，对于所有已经安装了支持`docker compose`命令的Docker版本的用户，只需要维护Docker CLI即可，进一步简化了部署和维护过程。这种命令的统一有助于减少对旧工具的依赖，确保项目可以更加平滑地迁移到最新的Docker环境，同时降低了未来潜在的技术债务。

通过这种方式，我们可以保证QAnything项目的部署过程更加直接和高效，减少了对过时工具的依赖，并使项目更加符合最新的技术标准。这对于提升用户体验和开发效率具有长远的积极影响。

希望这些改动能为项目带来价值，同时也希望能继续得到项目的宝贵经验。非常期待您的反馈，再次感谢您以及团队的辛勤工作。

此致
敬礼！