### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/qanything_kernel/connector/llm/llm_for_fastchat.py
+++ b/qanything_kernel/connector/llm/llm_for_fastchat.py
@@ -61,7 +61,7 @@ class OpenAICustomLLM(BaseAnswer, ABC):
             data=json.dumps(
                 {'prompts': [{'model': self.model, 'prompt': query, 'max_tokens': self.max_token}]}
             ),
-            headers=headers)
+            headers=headers, timeout=60)
 
         # {'prompts': [{'fits': True, 'tokenCount': 317, 'contextLength': 8192}]}
         result = response.json()
@@ -182,7 +182,7 @@ if __name__ == "__main__":
         data=json.dumps(
             {'prompts': [{'model': LOCAL_LLM_MODEL_NAME, 'prompt': query, 'max_tokens': 512}]}
         ),
-        headers=headers)
+        headers=headers, timeout=60)
 
     # {'prompts': [{'fits': True, 'tokenCount': 317, 'contextLength': 8192}]}
     result = response.json()

--- a/qanything_kernel/core/local_doc_qa.py
+++ b/qanything_kernel/core/local_doc_qa.py
@@ -40,7 +40,7 @@ class LocalDocQA:
         self.ocr_url = 'http://0.0.0.0:8010/ocr'
 
     def get_ocr_result(self, image_data: dict):
-        response = requests.post(self.ocr_url, json=image_data)
+        response = requests.post(self.ocr_url, json=image_data, timeout=60)
         response.raise_for_status()  # 如果请求返回了错误状态码，将会抛出异常
         return response.json()['results']
 
@@ -197,7 +197,7 @@ class LocalDocQA:
             return source_documents
         try:
             response = requests.post(f"{self.local_rerank_service_url}/rerank",
-                                     json={"passages": [doc.page_content for doc in source_documents], "query": query})
+                                     json={"passages": [doc.page_content for doc in source_documents], "query": query}, timeout=60)
             scores = response.json()
             for idx, score in enumerate(scores):
                 source_documents[idx].metadata['score'] = score

--- a/qanything_kernel/utils/loader/my_recursive_url_loader.py
+++ b/qanything_kernel/utils/loader/my_recursive_url_loader.py
@@ -62,7 +62,7 @@ class MyRecursiveUrlLoader(BaseLoader):
         visited.add(url)
 
         # Get all links that are relative to the root of the website
-        response = requests.get(url)
+        response = requests.get(url, timeout=60)
         soup = BeautifulSoup(response.text, "html.parser")
         all_links = [urljoin(url, link.get("href")) for link in soup.find_all("a")]
         # Filter children url of current url

--- a/third_party/FastChat/fastchat/serve/api_provider.py
+++ b/third_party/FastChat/fastchat/serve/api_provider.py
@@ -217,7 +217,7 @@ def ai2_api_stream_iter(
                 },
             },
         },
-    )
+    timeout=60)
 
     if res.status_code != 200:
         logger.error(f"unexpected response ({res.status_code}): {res.text}")

--- a/third_party/FastChat/fastchat/serve/base_model_worker.py
+++ b/third_party/FastChat/fastchat/serve/base_model_worker.py
@@ -93,7 +93,7 @@ class BaseModelWorker:
             "check_heart_beat": True,
             "worker_status": self.get_status(),
         }
-        r = requests.post(url, json=data)
+        r = requests.post(url, json=data, timeout=60)
         assert r.status_code == 200
 
     def send_heart_beat(self):

--- a/third_party/FastChat/fastchat/serve/gradio_web_server.py
+++ b/third_party/FastChat/fastchat/serve/gradio_web_server.py
@@ -125,9 +125,9 @@ def get_model_list(
     controller_url, register_openai_compatible_models, add_chatgpt, add_claude, add_palm
 ):
     if controller_url:
-        ret = requests.post(controller_url + "/refresh_all_workers")
+        ret = requests.post(controller_url + "/refresh_all_workers", timeout=60)
         assert ret.status_code == 200
-        ret = requests.post(controller_url + "/list_models")
+        ret = requests.post(controller_url + "/list_models", timeout=60)
         models = ret.json()["models"]
     else:
         models = []
@@ -400,8 +400,8 @@ def bot_response(
     else:
         # Query worker address
         ret = requests.post(
-            controller_url + "/get_worker_address", json={"model": model_name}
-        )
+            controller_url + "/get_worker_address", json={"model": model_name}, 
+        timeout=60)
         worker_addr = ret.json()["address"]
         logger.info(f"model_name: {model_name}, worker_addr: {worker_addr}")
 

--- a/third_party/FastChat/fastchat/serve/huggingface_api_worker.py
+++ b/third_party/FastChat/fastchat/serve/huggingface_api_worker.py
@@ -394,7 +394,7 @@ def create_huggingface_api_worker():
             "queue_length": sum([w.get_queue_length() for w in workers]),
         },
     }
-    r = requests.post(url, json=data)
+    r = requests.post(url, json=data, timeout=60)
     assert r.status_code == 200
 
     return args, workers

--- a/third_party/FastChat/fastchat/serve/monitor/dataset_release_scripts/lmsys_chat_1m/approve_all.py
+++ b/third_party/FastChat/fastchat/serve/monitor/dataset_release_scripts/lmsys_chat_1m/approve_all.py
@@ -3,11 +3,11 @@ import requests
 headers = {"authorization": "Bearer hf_XXX"}
 
 url = "https://huggingface.co/api/datasets/lmsys/lmsys-chat-1m/user-access-request/pending"
-a = requests.get(url, headers=headers)
+a = requests.get(url, headers=headers, timeout=60)
 
 for u in a.json():
     user = u["user"]["user"]
     url = "https://huggingface.co/api/datasets/lmsys/lmsys-chat-1m/user-access-request/grant"
-    ret = requests.post(url, headers=headers, json={"user": user})
+    ret = requests.post(url, headers=headers, json={"user": user}, timeout=60)
     print(user, ret.status_code)
     assert ret.status_code == 200

--- a/third_party/FastChat/fastchat/serve/multi_model_worker.py
+++ b/third_party/FastChat/fastchat/serve/multi_model_worker.py
@@ -279,7 +279,7 @@ def create_multi_model_worker():
             "queue_length": sum([w.get_queue_length() for w in workers]),
         },
     }
-    r = requests.post(url, json=data)
+    r = requests.post(url, json=data, timeout=60)
     assert r.status_code == 200
 
     return args, workers

--- a/third_party/FastChat/fastchat/serve/register_worker.py
+++ b/third_party/FastChat/fastchat/serve/register_worker.py
@@ -22,5 +22,5 @@ if __name__ == "__main__":
         "check_heart_beat": args.check_heart_beat,
         "worker_status": None,
     }
-    r = requests.post(url, json=data)
+    r = requests.post(url, json=data, timeout=60)
     assert r.status_code == 200

--- a/third_party/FastChat/fastchat/serve/test_message.py
+++ b/third_party/FastChat/fastchat/serve/test_message.py
@@ -14,15 +14,15 @@ def main():
         worker_addr = args.worker_address
     else:
         controller_addr = args.controller_address
-        ret = requests.post(controller_addr + "/refresh_all_workers")
-        ret = requests.post(controller_addr + "/list_models")
+        ret = requests.post(controller_addr + "/refresh_all_workers", timeout=60)
+        ret = requests.post(controller_addr + "/list_models", timeout=60)
         models = ret.json()["models"]
         models.sort()
         print(f"Models: {models}")
 
         ret = requests.post(
-            controller_addr + "/get_worker_address", json={"model": model_name}
-        )
+            controller_addr + "/get_worker_address", json={"model": model_name}, 
+        timeout=60)
         worker_addr = ret.json()["address"]
         print(f"worker_addr: {worker_addr}")
 
@@ -50,7 +50,7 @@ def main():
         headers=headers,
         json=gen_params,
         stream=True,
-    )
+    timeout=60)
 
     print(f"{conv.roles[0]}: {args.message}")
     print(f"{conv.roles[1]}: ", end="")

--- a/third_party/FastChat/fastchat/serve/test_throughput.py
+++ b/third_party/FastChat/fastchat/serve/test_throughput.py
@@ -14,15 +14,15 @@ def main():
         worker_addr = args.worker_address
     else:
         controller_addr = args.controller_address
-        ret = requests.post(controller_addr + "/refresh_all_workers")
-        ret = requests.post(controller_addr + "/list_models")
+        ret = requests.post(controller_addr + "/refresh_all_workers", timeout=60)
+        ret = requests.post(controller_addr + "/list_models", timeout=60)
         models = ret.json()["models"]
         models.sort()
         print(f"Models: {models}")
 
         ret = requests.post(
-            controller_addr + "/get_worker_address", json={"model": args.model_name}
-        )
+            controller_addr + "/get_worker_address", json={"model": args.model_name}, 
+        timeout=60)
         worker_addr = ret.json()["address"]
         print(f"worker_addr: {worker_addr}")
 
@@ -66,8 +66,8 @@ def main():
     def send_request(results, i):
         if args.test_dispatch:
             ret = requests.post(
-                controller_addr + "/get_worker_address", json={"model": args.model_name}
-            )
+                controller_addr + "/get_worker_address", json={"model": args.model_name}, 
+            timeout=60)
             thread_worker_addr = ret.json()["address"]
         else:
             thread_worker_addr = worker_addr
@@ -77,7 +77,7 @@ def main():
             headers=headers,
             json=ploads[i],
             stream=False,
-        )
+        timeout=60)
         k = list(
             response.iter_lines(chunk_size=8192, decode_unicode=False, delimiter=b"\0")
         )

--- a/third_party/FastChat/playground/test_embedding/test_classification.py
+++ b/third_party/FastChat/playground/test_embedding/test_classification.py
@@ -26,7 +26,7 @@ def get_embedding_from_api(word, model="vicuna-7b-v1.1"):
     headers = {"Content-Type": "application/json"}
     data = json.dumps({"model": model, "input": word})
 
-    response = requests.post(url, headers=headers, data=data)
+    response = requests.post(url, headers=headers, data=data, timeout=60)
     if response.status_code == 200:
         embedding = np.array(response.json()["data"][0]["embedding"])
         return embedding

--- a/third_party/FastChat/playground/test_embedding/test_semantic_search.py
+++ b/third_party/FastChat/playground/test_embedding/test_semantic_search.py
@@ -28,7 +28,7 @@ def get_embedding_from_api(word, model="vicuna-7b-v1.1"):
     headers = {"Content-Type": "application/json"}
     data = json.dumps({"model": model, "input": word})
 
-    response = requests.post(url, headers=headers, data=data)
+    response = requests.post(url, headers=headers, data=data, timeout=60)
     if response.status_code == 200:
         embedding = np.array(response.json()["data"][0]["embedding"])
         return embedding

--- a/third_party/FastChat/playground/test_embedding/test_sentence_similarity.py
+++ b/third_party/FastChat/playground/test_embedding/test_sentence_similarity.py
@@ -20,7 +20,7 @@ def get_embedding_from_api(word, model="vicuna-7b-v1.5"):
     headers = {"Content-Type": "application/json"}
     data = json.dumps({"model": model, "input": word})
 
-    response = requests.post(url, headers=headers, data=data)
+    response = requests.post(url, headers=headers, data=data, timeout=60)
     if response.status_code == 200:
         embedding = np.array(response.json()["data"][0]["embedding"])
         return embedding


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2FQAnything%7Cd6b15fd9f9e9d9078c6e634e4ccb2adcee630702)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->