### PR TITLE
Fix the bug of Excel reading

### DIFF
--- a/qanything_kernel/core/local_file.py
+++ b/qanything_kernel/core/local_file.py
@@ -85,11 +85,12 @@ class LocalFile:
         elif self.file_path.lower().endswith(".xlsx"):
             # loader = UnstructuredExcelLoader(self.file_path, mode="elements")
             docs = []
-            csv_file_path = self.file_path[:-5] + '.csv'
             xlsx = pd.read_excel(self.file_path, engine='openpyxl', sheet_name=None)
             for sheet in xlsx.keys():
+                df = xlsx[sheet]
+                df.dropna(how='all', inplace=True)
                 csv_file_path = self.file_path[:-5] + '_' + sheet + '.csv'
-                xlsx[sheet].to_csv(csv_file_path, index=False)
+                df.to_csv(csv_file_path, index=False)
                 loader = CSVLoader(csv_file_path, csv_args={"delimiter": ",", "quotechar": '"'})
                 docs += loader.load()
         elif self.file_path.lower().endswith(".pptx"):


### PR DESCRIPTION
Fixed a bug that caused the CPU and memory load to continue to increase and the process to be blocked for a long time when there were blank rows when reading Excel (maximum number of rows: 1048576)