### PR TITLE
修复错误将chunk_size更新为chunks_number的问题

### DIFF
--- a/qanything_kernel/connector/database/mysql/mysql_client.py
+++ b/qanything_kernel/connector/database/mysql/mysql_client.py
@@ -460,7 +460,7 @@ class KnowledgeBaseManager:
 
     #  更新file中的chunk_number
     def update_chunks_number(self, file_id, chunks_number):
-        query = "UPDATE File SET chunk_size = %s WHERE file_id = %s"
+        query = "UPDATE File SET chunks_number = %s WHERE file_id = %s"
         self.execute_query_(query, (chunks_number, file_id), commit=True)
 
     def update_file_status(self, file_id, status):

--- a/qanything_kernel/dependent_server/insert_files_serve/insert_files_server.py
+++ b/qanything_kernel/dependent_server/insert_files_serve/insert_files_server.py
@@ -111,7 +111,6 @@ async def process_data(retriever, milvus_kb, mysql_client, file_info, time_recor
         insert_time = time.perf_counter()
         time_record.update(insert_time_record)
         insert_logger.info(f'insert time: {insert_time - start}')
-        mysql_client.update_chunks_number(local_file.file_id, chunks_number)
     except asyncio.TimeoutError:
         insert_logger.error(f'Timeout: milvus insert took longer than {insert_timeout_seconds} seconds')
         expr = f'file_id == \"{local_file.file_id}\"'


### PR DESCRIPTION
KnowledgeBaseManager类中，更新File表的chunk_number字段使用的方法update_chunks_number存在sql语句错误。
实际为"UPDATE File SET chunk_size = %s WHERE file_id = %s"。这会错误地修改chunk_size，导致chunk_size和chunks_number值相同。
![image](https://github.com/user-attachments/assets/e0f5ffb4-1b4b-4dc7-95c1-f1d8af871685)

同时，在文件插入向量数据库结束后，原代码会有针对chunks_number等信息的统一修改。
![image](https://github.com/user-attachments/assets/b11b5b82-5ae1-47e6-b1c6-68e5c83ea667)

所以可以将insert_files_server.py中，process_data中对chunks_number做的更新语句：mysql_client.update_chunks_number(local_file.file_id, chunks_number)进行删除。
修改后，文件上传成功后chunks_number和chunk_size的值完全正确。
![image](https://github.com/user-attachments/assets/c42b3537-5775-43a9-8d43-750525e690a4)
