### PR TITLE
Bug Fix: Reranker Chunk Overlap and CHUNK_SIZE Exceedance

### DIFF
--- a/qanything_kernel/connector/database/milvus/milvus_client.py
+++ b/qanything_kernel/connector/database/milvus/milvus_client.py
@@ -254,7 +254,7 @@ class MilvusClient:
                         merge_content = group_chunk_map[expand_index]
                         if docs_len + len(merge_content) > CHUNK_SIZE:
                             id_list = sorted(list(id_set))
-                            id_lists = id_lists.append(id_list)
+                            id_lists.append(id_list)
                             break_flag = True
                             break
                         else:

--- a/qanything_kernel/connector/database/milvus/milvus_client.py
+++ b/qanything_kernel/connector/database/milvus/milvus_client.py
@@ -221,7 +221,7 @@ class MilvusClient:
     def process_group(self, group):
         new_cands = []
         group.sort(key=lambda x: int(x.metadata['chunk_id'].split('_')[-1]))
-        id_set = set()
+        id_lists = []
         file_id = group[0].metadata['file_id']
         file_name = group[0].metadata['file_name']
         group_scores_map = {}
@@ -242,6 +242,7 @@ class MilvusClient:
 
         group_file_chunk_num = list(group_chunk_map.keys())
         for cand_doc in group:
+            id_set = set()
             current_chunk_id = int(cand_doc.metadata['chunk_id'].split('_')[-1])
             doc = copy.deepcopy(cand_doc)
             id_set.add(current_chunk_id)
@@ -252,6 +253,8 @@ class MilvusClient:
                     if expand_index in group_file_chunk_num:
                         merge_content = group_chunk_map[expand_index]
                         if docs_len + len(merge_content) > CHUNK_SIZE:
+                            id_list = sorted(list(id_set))
+                            id_lists = id_lists.append(id_list)
                             break_flag = True
                             break
                         else:
@@ -260,8 +263,6 @@ class MilvusClient:
                 if break_flag:
                     break
 
-        id_list = sorted(list(id_set))
-        id_lists = self.seperate_list(id_list)
         for id_seq in id_lists:
             for id in id_seq:
                 if id == id_seq[0]:


### PR DESCRIPTION
Fixed an issue where the reranker would exceed the predefined CHUNK_SIZE, which also negatively impacted reranking precision. The root cause was the separate_list function, which groups adjacent chunks based on their proximity in the original document. In cases where the document is small or adjacent chunks are close together, the grouping logic caused overlap between chunk groups. This resulted in individual chunk sets interfering with each other and the total length of a group exceeding the intended CHUNK_SIZE.