### PR TITLE
feat: 避免全局变量在不同服务中重复创建，极大减少内存占用

### DIFF
--- a/qanything_kernel/dependent_server/embedding_server/embedding_server.py
+++ b/qanything_kernel/dependent_server/embedding_server/embedding_server.py
@@ -46,6 +46,16 @@ async def embedding(request):
 
     return json(result_data)
 
+@get_time_async
+@app.route("/compute_token_len", methods=["POST"])
+async def compute_token_len(request):
+    data = request.json
+    text = data.get('text')
+
+    onnx_backend: EmbeddingOnnxBackend = request.app.ctx.onnx_backend
+    token_num = len(onnx_backend._tokenizer.encode(text, add_special_tokens=True))
+
+    return {"token_num": token_num}
 
 @app.listener('before_server_start')
 async def setup_onnx_backend(app, loop):

--- a/qanything_kernel/dependent_server/rerank_server/rerank_server.py
+++ b/qanything_kernel/dependent_server/rerank_server/rerank_server.py
@@ -47,6 +47,17 @@ async def rerank(request):
 
     return json(result_data)
 
+@get_time_async
+@app.route("/compute_token_len", methods=["POST"])
+async def compute_token_len(request):
+    data = request.json
+    text = data.get('text')
+
+    onnx_backend: RerankOnnxBackend = request.app.ctx.onnx_backend
+    token_num = len(onnx_backend._tokenizer.encode(text, add_special_tokens=True))
+
+    return {"token_num": token_num}
+
 
 @app.listener('before_server_start')
 async def setup_onnx_backend(app, loop):

--- a/qanything_kernel/utils/general_utils.py
+++ b/qanything_kernel/utils/general_utils.py
@@ -1,7 +1,7 @@
 from sanic.request import Request
 from sanic.exceptions import BadRequest
 from qanything_kernel.utils.custom_log import debug_logger, embed_logger, rerank_logger
-from qanything_kernel.configs.model_config import (KB_SUFFIX, UPLOAD_ROOT_PATH, LOCAL_EMBED_PATH, LOCAL_RERANK_PATH)
+from qanything_kernel.configs.model_config import (KB_SUFFIX, UPLOAD_ROOT_PATH, LOCAL_RERANK_SERVICE_URL, LOCAL_EMBED_SERVICE_URL)
 from transformers import AutoTokenizer
 import pandas as pd
 import inspect
@@ -32,6 +32,7 @@ import email
 import chardet
 import mimetypes
 from io import BytesIO
+import requests
 
 __all__ = ['isURL', 'get_time', 'get_time_async', 'format_source_documents', 'safe_get', 'truncate_filename',
            'shorten_data', 'read_files_with_extensions', 'validate_user_id', 'get_invalid_user_id_msg', 'num_tokens',
@@ -227,19 +228,22 @@ def num_tokens(text: str, model: str = 'gpt-3.5-turbo-0613') -> int:
     encoding = tiktoken.encoding_for_model(model)
     return len(encoding.encode(text, disallowed_special=()))
 
-
-embedding_tokenizer = AutoTokenizer.from_pretrained(LOCAL_EMBED_PATH, local_files_only=True)
-rerank_tokenizer = AutoTokenizer.from_pretrained(LOCAL_RERANK_PATH, local_files_only=True)
-
-
 def num_tokens_embed(text: str) -> int:
     """Return the number of tokens in a string."""
-    return len(embedding_tokenizer.encode(text, add_special_tokens=True))
+    server_url = f"http://{LOCAL_EMBED_SERVICE_URL}/compute_token_len"
+    response = requests.post(server_url, json={"text": text})
+    if response.status_code == 200:
+        return response.json().get("token_num", 0)
+    raise ValueError("Error occurred while computing token length")
 
 
 def num_tokens_rerank(text: str) -> int:
     """Return the number of tokens in a string."""
-    return len(rerank_tokenizer.encode(text, add_special_tokens=True))
+    server_url = f"http://{LOCAL_RERANK_SERVICE_URL}/compute_token_len"
+    response = requests.post(server_url, json={"text": text})
+    if response.status_code == 200:
+        return response.json().get("token_num", 0)
+    raise ValueError("Error occurred while computing token length")
 
 
 def shorten_data(data):


### PR DESCRIPTION
### 问题

在使用这个项目过程中，发现在主服务qanything_server中有两个全局变量：[embedding_tokenizer 和 rerank_tokenizer](https://github.com/netease-youdao/QAnything/blob/65de10426b99d5945b8c616a4814afa5a92826cb/qanything_kernel/utils/general_utils.py#L231-L232)在不同的依赖服务中都会被加载，而这两个全局变量在加载tokenizer模型时会占用约1.8G的内存。而这两个全局变量仅用于计算token长度。

例如：

在 [insert_files_server](https://github.com/netease-youdao/QAnything/blob/qanything-v2/qanything_kernel/dependent_server/insert_files_serve/insert_files_server.py) 中，会从 [general_utils](https://github.com/netease-youdao/QAnything/blob/qanything-v2/qanything_kernel/utils/general_utils.py)中导入[get_time_async](https://github.com/netease-youdao/QAnything/blob/65de10426b99d5945b8c616a4814afa5a92826cb/qanything_kernel/utils/general_utils.py#L162)，而在导入该函数时，会同时从 [general_utils](https://github.com/netease-youdao/QAnything/blob/qanything-v2/qanything_kernel/utils/general_utils.py)中导入embedding_tokenizer 和 rerank_tokenizer这两个全局变量。

general_utils模块在多个依赖服务中都有使用，使得这些依赖服务在导入该模块时会重复创建这两个资源，造成大量的内存占用。

### 解决方案

在embedding_server和rerank_server中本身会创建对应的tokenizer，因此可以复用这两个服务中的tokenizer资源，让两个服务分别提供一个api用于计算token长度。在general_utils中需要使用tokenizer时，调用embedding_server和rerank_server中的计算服务即可。

### 测试结果

经过测试，通过这种方式，整体的内存占用减少约一半，同时服务启动时间减少约一半。

```txt
CONTAINER ID   NAME                      CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS 
d1ff268c7b18   qanything-container-local 2.59%     12.58GiB / 91.94GiB   13.69%    6.83MB / 7.09MB   0B / 10.2MB       1256 
c6df3a6e552f   es-container-local        0.18%     1.796GiB / 91.94GiB   1.95%     396kB / 758kB     0B / 12MB         283 
5db62d643c85   mysql-container-local     0.34%     514.3MiB / 91.94GiB   0.55%     3.64MB / 3.13MB   151MB / 750MB     66 
2387a08c1962   milvus-minio-local        0.01%     96.64MiB / 91.94GiB   0.10%     2.6MB / 3.26MB    12.7MB / 8.36MB   38 
dab6fe80a48f   milvus-standalone-local   2.59%     166.5MiB / 91.94GiB   0.18%     6.54MB / 5.81MB   0B / 6.62MB       129 
7cc8902fdf4d   milvus-etcd-local         2.87%     20.73MiB / 91.94GiB   0.02%     3.09MB / 2.31MB   0B / 85.4MB       37 
```