### PR TITLE
fix: correct typos 'occured' and 'seperate'

### DIFF
--- a/qanything_kernel/connector/database/milvus/milvus_client.py
+++ b/qanything_kernel/connector/database/milvus/milvus_client.py
@@ -205,7 +205,7 @@ class MilvusClient:
         valid_ids = [result['file_id'] for result in res]
         return valid_ids
 
-    def seperate_list(self, ls: List[int]) -> List[List[int]]:
+    def separate_list(self, ls: List[int]) -> List[List[int]]:
         lists = []
         ls1 = [ls[0]]
         for i in range(1, len(ls)):
@@ -261,7 +261,7 @@ class MilvusClient:
                     break
 
         id_list = sorted(list(id_set))
-        id_lists = self.seperate_list(id_list)
+        id_lists = self.separate_list(id_list)
         for id_seq in id_lists:
             for id in id_seq:
                 if id == id_seq[0]:

--- a/qanything_kernel/dependent_server/pdf_parser_server/pdf_to_markdown/core/layout/table_rec/utils_table_recover.py
+++ b/qanything_kernel/dependent_server/pdf_parser_server/pdf_to_markdown/core/layout/table_rec/utils_table_recover.py
@@ -57,7 +57,7 @@ def compute_poly_iou(a: np.ndarray, b: np.ndarray) -> float:
         inter_area = poly1.intersection(poly2).area
         union_area = MultiPoint(union_poly).convex_hull.area
     except shapely.geos.TopologicalError:
-        print("shapely.geos.TopologicalError occured, iou set to 0")
+        print("shapely.geos.TopologicalError occurred, iou set to 0")
         return 0.0
 
     if union_area == 0:


### PR DESCRIPTION
Fixed spelling errors:
- occured → occurred (utils_table_recover.py)
- seperate → separate (milvus_client.py)