### PR TITLE
fix(docker): add .gitattributes to force LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Normalize line endings for scripts used inside Linux containers.
+# Prevents Windows CRLF checkouts from breaking docker entrypoints.
+* text=auto
+*.sh text eol=lf
+*.bash text eol=lf
+Dockerfile text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf


### PR DESCRIPTION
## Summary
- Add root `.gitattributes` forcing LF for shell/docker files so Windows clones do not break Linux container entrypoints with CRLF.

Fixes #664

## Testing plan
- [ ] Fresh clone on Windows; shell scripts are LF.
- [ ] Docker start path no longer fails due to `\r` in scripts.